### PR TITLE
Add username/password to connect message for subscriber

### DIFF
--- a/bin/net-mqtt-sub
+++ b/bin/net-mqtt-sub
@@ -65,6 +65,14 @@ is 0 - read forever.
 
 Short for B<-count 1>.  Read one message and exit.
 
+=item B<-username>
+
+Username to be used for authentication in the connection message.
+
+=item B<-password>
+
+Password to be used for authentication in the connection message.
+
 =back
 
 =head1 DESCRIPTION
@@ -91,12 +99,16 @@ my $port = 1883;
 my $count;
 my $client_id;
 my $keep_alive_timer = 120;
+my $user_name;
+my $password;
 GetOptions('help|?' => \$help,
            'man' => \$man,
            'verbose+' => \$verbose,
            'host=s' => \$host,
            'port=i' => \$port,
            'count=i' => \$count,
+           'username=s' => \$user_name,
+           'password=s' => \$password,
            'one|1' => sub { $count = 1 },
            'client_id|client-id|C=s' => \$client_id,
            'keepalive=i' => \$keep_alive_timer) or pod2usage(2);
@@ -114,7 +126,9 @@ my $mid = 1;
 my $next_ping;
 my $got_ping_response = 1;
 my @connect = ( message_type => MQTT_CONNECT,
-                keep_alive_timer => $keep_alive_timer );
+                keep_alive_timer => $keep_alive_timer,
+		user_name => $user_name,
+		password => $password );
 push @connect, client_id => $client_id if (defined $client_id);
 send_message($socket, @connect);
 my $msg = read_message($socket, $buf) or die "No ConnAck\n";


### PR DESCRIPTION
In order to be able to connect to data.sparkfun.com you need to pass a username/password
in the connect message to the broker. This pull request adds this option for the subscriber script.

I've verified it works with

```
net-mqtt-sub -host data.sparkfun.com -username lieven -password test -verbose output/YGVr5qlomEIORMAo127x/a
```

I also checked that all tests except the end-of-line test run fine when I run `dzil test`. The EOL test already failed on the master branch on my machine when I freshly cloned it, so I did not look further into this.

Thanks for taking the time to write and publish this module!
